### PR TITLE
Increasing timeouts

### DIFF
--- a/templates/default/nginx.conf.erb
+++ b/templates/default/nginx.conf.erb
@@ -33,8 +33,9 @@ http {
   include               /etc/nginx/sites-enabled/*;
 
   # Timeout Settings
-  proxy_connect_timeout 1s;
-  proxy_send_timeout    1s;
-  proxy_read_timeout    1s;
+  proxy_connect_timeout 30s;
+  proxy_send_timeout    30s;
+  proxy_read_timeout    30s;
+  send_timeout          30s;
 
 }


### PR DESCRIPTION
The 1 second timeouts appeared to be causing 504s when the site is under higher load. It would probably be better if the site just loaded a bit slower rather then showing a nasty error message.